### PR TITLE
Add Documentation URL Response Code w/ Debug Option

### DIFF
--- a/oshwa_scrape.py
+++ b/oshwa_scrape.py
@@ -4,6 +4,7 @@ from datetime import date
 from urllib import request
 from urllib.error import HTTPError, URLError
 import ssl
+import socket
 from bs4 import BeautifulSoup as bs
 
 #debugging switch

--- a/oshwa_scrape.py
+++ b/oshwa_scrape.py
@@ -7,10 +7,9 @@ import ssl
 import socket
 from bs4 import BeautifulSoup as bs
 
-#debugging switch
 parser = argparse.ArgumentParser(description='Create CSV of OSHWA Certified projects.')
-parser.add_argument('--debug', action='store_true', help='enable debugging of the documentation status check')
-parser.add_argument('--doccheck', action='store_true', help='return HTTP status codes for documentation links')
+parser.add_argument('--debug', action='store_true', help='enable debugging of the documentation status check') #debugging switch
+parser.add_argument('--doccheck', action='store_true', help='return HTTP status codes for documentation links') #documentation check switch
 args = parser.parse_args()
 global debug_enable
 if args.debug:

--- a/oshwa_scrape.py
+++ b/oshwa_scrape.py
@@ -95,7 +95,7 @@ for url in project_page_urls:
         else:
             pass
         try:
-            conn = request.urlopen(sani_doc_url, context=ssl._create_unverified_context())
+            conn = request.urlopen(sani_doc_url, timeout=5, context=ssl._create_unverified_context())
             return conn.getcode()
         except HTTPError as e1:
             return e1.code
@@ -103,6 +103,8 @@ for url in project_page_urls:
             return e2.reason
         except ssl.SSLError as e3:
             return e3.reason
+        except socket.timeout as e4:
+            return 'Timed Out'
 
     project_fields.append(getResponseCode(doc_url)) #Documentation Status
 

--- a/oshwa_scrape.py
+++ b/oshwa_scrape.py
@@ -60,10 +60,10 @@ for url in project_page_urls:
         return (doc_url)
     
     def getResponseCode(doc_url):
-        mod_doc_url = sanitizeURL(doc_url)
-        print ('Probing ' + mod_doc_url)
+        sani_doc_url = sanitizeURL(doc_url)
+        print ('Probing ' + sani_doc_url)
         try:
-            conn = request.urlopen(mod_doc_url, context=ssl._create_unverified_context())
+            conn = request.urlopen(sani_doc_url, context=ssl._create_unverified_context())
             return conn.getcode()
         except HTTPError as e1:
             return e1.code

--- a/oshwa_scrape.py
+++ b/oshwa_scrape.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup as bs
 #debugging switch
 parser = argparse.ArgumentParser(description='Create CSV of OSHWA Certified projects.')
 parser.add_argument('--debug', action='store_true', help='enable debugging of the documentation status check')
+parser.add_argument('--doccheck', action='store_true', help='return HTTP status codes for documentation links')
 args = parser.parse_args()
 global debug_enable
 if args.debug:
@@ -106,7 +107,10 @@ for url in project_page_urls:
         except socket.timeout as e4:
             return 'Timed Out'
 
-    project_fields.append(getResponseCode(doc_url)) #Documentation Status
+    if args.doccheck:
+        project_fields.append(getResponseCode(doc_url)) #Documentation Status
+    else:
+        project_fields.append('Not Checked') 
 
     project_data.append(project_fields)
     if debug_enable is True:


### PR DESCRIPTION
These changes append a new column with the HTTP response code for the Documentation URL. In the process of figuring out this feature I added some debugging functionality, which can be enabled with the `--debug` flag.